### PR TITLE
Doctest flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,6 @@ jobs:
         run: stack build
 
       - name: Run tests
+        env:
+          DISTRIBUTORS_RUN_DOCTESTS: "1"
         run: stack test

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -27,7 +27,7 @@ main = do
   hspec $ do
     when shouldRunDoctests $
       describe "doctest" $
-        it "runs module documentation examples" doctests
+        it "should run haddock examples" doctests
     describe "regexGrammar" $ for_ regexExamples $ testGrammar False regexGrammar
     describe "semverGrammar" $ for_ semverExamples $ testCtxGrammar True semverGrammar
     describe "semverCtxGrammar" $ for_ semverExamples $ testCtxGrammar True semverCtxGrammar

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,7 +5,9 @@ import Control.Lens.Grammar
 import Control.Monad (when)
 import Data.IORef
 import Data.List (genericLength)
+import Data.Maybe (isJust)
 import Data.Profunctor.Types (Star (..))
+import System.Environment (lookupEnv)
 import Test.DocTest
 import Test.Hspec
 
@@ -21,7 +23,11 @@ import Properties.Kleene
 
 main :: IO ()
 main = do
+  shouldRunDoctests <- isJust <$> lookupEnv "DISTRIBUTORS_RUN_DOCTESTS"
   hspec $ do
+    when shouldRunDoctests $
+      describe "doctest" $
+        it "runs module documentation examples" doctests
     describe "regexGrammar" $ for_ regexExamples $ testGrammar False regexGrammar
     describe "semverGrammar" $ for_ semverExamples $ testCtxGrammar True semverGrammar
     describe "semverCtxGrammar" $ for_ semverExamples $ testCtxGrammar True semverCtxGrammar
@@ -34,8 +40,6 @@ main = do
     describe "Parsector try rollback" tryRollbackTests
     describe "Kleene" kleeneProperties
     describe "meander" meanderProperties
-    describe "doctest" $
-      it "runs module documentation examples" doctests
 
 tryRollbackTests :: Spec
 tryRollbackTests = do


### PR DESCRIPTION
Fix #23

Doctests are flaky with respect to requirements. Failing doctests shouldn't interrupt user flow except at PR stage. So, hide the doctest behind an Env Var which is set in CI (and which can be easily flagged to run by a user if desired)